### PR TITLE
made m1 mac compatible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ COPY frontend/ .
 RUN npm run build
 
 # first stage
-FROM mongo:6.0.5-jammy
+# FROM mongo:6.0.5-jammy
+FROM arm64v8/mongo:6.0.6
 WORKDIR /dcef
 RUN apt-get update && apt-get install python3.11 python3-pip nginx -y
 RUN mkdir -p /dcef/exports/


### PR DESCRIPTION
By changing the mongo version to an arm version this works on my M1 mac. However while server icons do work, I can't get images and media to work which could be due to me making a bad backup or I could have broken something.

I think being able to see messages without attachments is better than not being able to run the project at all.