### PR TITLE
Build docker image for arm64

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,6 +15,12 @@ jobs:
     - name: Check out the repo
       uses: actions/checkout@v3
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Log in to Docker Hub
       uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
       with:
@@ -31,6 +37,7 @@ jobs:
       uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
       with:
         context: .
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Hi, was getting this on my rpi 5:
```bash
$ docker run --restart=always --volume "$(pwd):/dcef/exports" --volume dcef_cache:/dcef/cache --name dcef -p 21011:21011 -it slada/dcef:main
...
d4a604f6028e: Pull complete
80ef53282b14: Pull complete
Digest: sha256:cf75d77091d8448f0f404319f3775b1f033233b4dcee3503eb2c938de5515a4e
Status: Downloaded newer image for slada/dcef:main
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
exec /usr/local/bin/docker-entrypoint.sh: exec format error
```

it now uses qemu to also [build for arm64](https://hub.docker.com/repository/docker/ritiek/dcef/tags) ([using source from main branch](https://github.com/ritiek/DiscordChatExporter-frontend/tree/main)) which looks to work fine on my rpi 5 running raspberry pi os (debian 12 bookworm) when pulling the image using:
```bash
$ docker run --restart=always --volume "$(pwd):/dcef/exports" --volume dcef_cache:/dcef/cache --name dcef -p 21011:21011 -it ritiek/dcef:main
```