### PR TITLE
Subtext (small text) support

### DIFF
--- a/src/dcef/frontend/src/js/markdownParser.ts
+++ b/src/dcef/frontend/src/js/markdownParser.ts
@@ -297,6 +297,14 @@ const customHeading = {
   },
 }
 
+// subtext
+// -# Subtext
+const subtext : SimpleMarkdown.ParserRule & SimpleMarkdown.HtmlOutputRule = {
+  order: SimpleMarkdown.defaultRules.heading.order - 0.15,
+  match: source => /^ *-# ([^\n]+)/.exec(source),
+  parse: capture => ({ type: 'subtext', content: capture[1] }),
+  html: node => `<span class="message-subtext">${node.content}</span>`
+}
 
 // old emojis
 // :kekw:
@@ -533,6 +541,7 @@ const badlyFormattedCodeBlock = {
 export const rules = {
     array: SimpleMarkdown.defaultRules.array,
     customHeading: customHeading,
+    subtext: subtext,
     // heading: SimpleMarkdown.defaultRules.heading,  // disabled because customHeading is used instead
     nptable: SimpleMarkdown.defaultRules.nptable,
     // lheading: SimpleMarkdown.defaultRules.lheading,

--- a/src/dcef/frontend/src/lib/message/MessageMarkdown.svelte
+++ b/src/dcef/frontend/src/lib/message/MessageMarkdown.svelte
@@ -127,6 +127,10 @@
         margin-bottom: 8px;
         font-size: 16px;
     }
+    :global(.message-subtext) {
+        color: #c5c6ca;
+        font-size: 14px;
+    }
 
     :global(.message-emoji),
     :global(.d-emoji) {


### PR DESCRIPTION
There is a Discord-flavored Markdown syntax called subtext where putting `-#` in the beginning of a line makes the following text appear smaller and dimmer than regular text.
This feature is documented in: https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline#h_01J2HBMKS7587KC8PMAJ47PZR2
Currently, DiscordChatExporter-frontend does not support this syntax and mistakes it as level 1 heading (`#`). This PR will fix that behavior so that lines beginning with `-#` will appear roughly the same way as in Discord.